### PR TITLE
Workaround for error on macos with clang

### DIFF
--- a/boot-terp/lump.c
+++ b/boot-terp/lump.c
@@ -58,7 +58,7 @@ static void traceback (void);
 static void
 traceback_error (const char *plaint)
 {
-  strcpy (output, plaint);
+  if (output != plaint) strcpy (output, plaint);
   out = output + strlen (plaint);
   *out++ = '\n';
   traceback ();


### PR DESCRIPTION
The build of ichbins fails on macos without this patch; it seems that the runtime doesn't like "overlapping" source and target for strcpy.

Thanks for sharing ichbins!